### PR TITLE
fix: ignored z endstop when single z endstop is used

### DIFF
--- a/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
@@ -121,7 +121,9 @@
 #elif ANY(TRIGORILLA_MAPPING_CHIRON, TRIGORILLA_MAPPING_I3MEGA)
   // Chiron uses AUX header for Y and Z endstops
   #define Y_STOP_PIN                          42  // AUX (1)
-  #define Z_STOP_PIN                          43  // AUX (2)
+  #if DISABLED(KNUTWURST_ONE_Z_ENDSTOP)
+    #define Z_STOP_PIN                          43  // AUX (2)
+  #endif
   #ifndef Z2_STOP_PIN
      #define Z2_STOP_PIN                      18  // Z-
   #endif


### PR DESCRIPTION
### Description
I noticed zstop is not working in my MEGA_1G_BLT_10 after I flashed original version.
I found a bug and fixed it.
Probably this PR also fixes this issue: https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/issues/510

For TRIGORILLA_MAPPING_I3MEGA original code redefined Z_STOP_PIN to 43 which overrode original pin 18 (which is used as Z2_STOP_PIN in other boards).
I just excluded KNUTWURST_ONE_Z_ENDSTOP from override.

### Requirements

MEGA_1G with only one z endstop.

### Benefits
Fixes bug that makes this software unusable for MEGA_1G boards

### Configurations
/
### Related Issues
https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/issues/510